### PR TITLE
Adjust omni-wheel kinematics

### DIFF
--- a/omni_robot_controller/robot_control_node.py
+++ b/omni_robot_controller/robot_control_node.py
@@ -92,6 +92,8 @@ class RobotControlNode(Node):
 
         # Initialize variables from kinematics parameters
         self.robot_radius = self.get_parameter('kinematics.robot_radius_m').get_parameter_value().double_value
+        # Radius from robot center to each wheel for kinematics calculations
+        self.wheel_base_radius = self.get_parameter('kinematics.robot_radius_m').get_parameter_value().double_value
         self.max_wheel_speed = self.get_parameter('kinematics.max_wheel_speed_mps').get_parameter_value().double_value
         if self.max_wheel_speed <= 0:
             self.get_logger().error(f"kinematics.max_wheel_speed_mps must be positive. Value: {self.max_wheel_speed}. Defaulting to 0.5 m/s.")
@@ -642,14 +644,26 @@ class RobotControlNode(Node):
 
     def calculate_wheel_efforts(self, vx_mps, vy_mps, v_omega_radps):
         # ホイールの配置角度（ラジアン）
-        angle_w1 = 0           # ホイール1: 前方
-        angle_w2 = 2 * math.pi / 3  # ホイール2: 左後方 120°
-        angle_w3 = 4 * math.pi / 3  # ホイール3: 右後方 240°
+        angle_w1 = math.pi / 3      # ホイール1: 60°
+        angle_w2 = math.pi          # ホイール2: 180°
+        angle_w3 = 5 * math.pi / 3  # ホイール3: 300°
 
         # 個々のホイール速度[m/s]を逆運動学で算出
-        v_w1 = vx_mps * math.cos(angle_w1) + vy_mps * math.sin(angle_w1) + v_omega_radps * self.wheel_base_radius
-        v_w2 = vx_mps * math.cos(angle_w2) + vy_mps * math.sin(angle_w2) + v_omega_radps * self.wheel_base_radius
-        v_w3 = vx_mps * math.cos(angle_w3) + vy_mps * math.sin(angle_w3) + v_omega_radps * self.wheel_base_radius
+        v_w1 = (
+            -math.sin(angle_w1) * vx_mps
+            + math.cos(angle_w1) * vy_mps
+            + v_omega_radps * self.wheel_base_radius
+        )
+        v_w2 = (
+            -math.sin(angle_w2) * vx_mps
+            + math.cos(angle_w2) * vy_mps
+            + v_omega_radps * self.wheel_base_radius
+        )
+        v_w3 = (
+            -math.sin(angle_w3) * vx_mps
+            + math.cos(angle_w3) * vy_mps
+            + v_omega_radps * self.wheel_base_radius
+        )
 
         # 各ホイールの最大回転速度[rad/s]
         max_wheel_speed = self.max_wheel_speed  # パラメータで設定済み

--- a/test/test_kinematics.py
+++ b/test/test_kinematics.py
@@ -15,20 +15,16 @@ def calculate_expected_wheel_efforts(vx_mps, vy_mps, v_omega_radps, robot_radius
         raise ValueError("max_wheel_speed must be positive")
 
     L = robot_radius
+    angles = [math.pi / 3, math.pi, 5 * math.pi / 3]
 
-    v_w1 = vy_mps + L * v_omega_radps
-    v_w2 = (-math.sqrt(3)/2.0 * vx_mps) - (0.5 * vy_mps) + (L * v_omega_radps)
-    v_w3 = (math.sqrt(3)/2.0 * vx_mps) - (0.5 * vy_mps) + (L * v_omega_radps)
+    v_ws = [
+        -math.sin(th) * vx_mps + math.cos(th) * vy_mps + v_omega_radps * L
+        for th in angles
+    ]
 
-    effort1 = v_w1 / max_wheel_speed
-    effort2 = v_w2 / max_wheel_speed
-    effort3 = v_w3 / max_wheel_speed
+    efforts = [max(min(v / max_wheel_speed, 1.0), -1.0) for v in v_ws]
 
-    effort1 = max(min(effort1, 1.0), -1.0)
-    effort2 = max(min(effort2, 1.0), -1.0)
-    effort3 = max(min(effort3, 1.0), -1.0)
-
-    return [effort1, effort2, effort3]
+    return efforts
 
 @pytest.fixture
 def kinematics_params():
@@ -40,20 +36,28 @@ def kinematics_params():
 def test_forward_motion(kinematics_params):
     vx, vy, v_omega = 0.1, 0.0, 0.0
     efforts = calculate_expected_wheel_efforts(vx, vy, v_omega, **kinematics_params)
-    # v_w1 = 0, v_w2 = -sqrt(3)/2*0.1 = -0.0866, v_w3 = sqrt(3)/2*0.1 = 0.0866
-    # e1 = 0, e2 = -0.0866/0.5 = -0.1732, e3 = 0.0866/0.5 = 0.1732
-    assert efforts[0] == pytest.approx(0.0)
-    assert efforts[1] == pytest.approx(-0.1732, abs=1e-4)
+    # v_w1 = -(sqrt(3)/2)*0.1 = -0.0866
+    # v_w2 = ~0
+    # v_w3 = (sqrt(3)/2)*0.1 = 0.0866
+    # e1 = -0.0866/0.5 = -0.1732
+    # e2 = 0
+    # e3 = 0.0866/0.5 = 0.1732
+    assert efforts[0] == pytest.approx(-0.1732, abs=1e-4)
+    assert efforts[1] == pytest.approx(0.0, abs=1e-4)
     assert efforts[2] == pytest.approx(0.1732, abs=1e-4)
 
 def test_strafe_left_motion(kinematics_params):
     vx, vy, v_omega = 0.0, 0.1, 0.0
     efforts = calculate_expected_wheel_efforts(vx, vy, v_omega, **kinematics_params)
-    # v_w1 = 0.1, v_w2 = -0.5*0.1 = -0.05, v_w3 = -0.5*0.1 = -0.05
-    # e1 = 0.1/0.5 = 0.2, e2 = -0.05/0.5 = -0.1, e3 = -0.05/0.5 = -0.1
-    assert efforts[0] == pytest.approx(0.2)
-    assert efforts[1] == pytest.approx(-0.1)
-    assert efforts[2] == pytest.approx(-0.1)
+    # v_w1 = 0.05
+    # v_w2 = -0.1
+    # v_w3 = 0.05
+    # e1 = 0.05/0.5 = 0.1
+    # e2 = -0.1/0.5 = -0.2
+    # e3 = 0.05/0.5 = 0.1
+    assert efforts[0] == pytest.approx(0.1)
+    assert efforts[1] == pytest.approx(-0.2)
+    assert efforts[2] == pytest.approx(0.1)
 
 def test_rotate_ccw_motion(kinematics_params):
     vx, vy, v_omega = 0.0, 0.0, 0.2
@@ -78,19 +82,19 @@ def test_clipping_motion(kinematics_params):
     # If vx = 0.7, then sqrt(3)/2 * 0.7 = 0.866 * 0.7 = 0.6062, which is > 0.5
     vx, vy, v_omega = 0.7, 0.0, 0.0
     efforts = calculate_expected_wheel_efforts(vx, vy, v_omega, **kinematics_params)
-    # v_w1 = 0
-    # v_w2 = -0.6062 => e2_unclipped = -0.6062 / 0.5 = -1.2124 => e2_clipped = -1.0
-    # v_w3 = 0.6062  => e3_unclipped = 0.6062 / 0.5 = 1.2124  => e3_clipped = 1.0
-    assert efforts[0] == pytest.approx(0.0)
-    assert efforts[1] == pytest.approx(-1.0)
+    # v_w1 = -(sqrt(3)/2)*0.7 = -0.6062 => e1 = -1.2124 => clipped to -1
+    # v_w2 ≈ 0       => e2 = 0
+    # v_w3 = (sqrt(3)/2)*0.7 = 0.6062 => e3 = 1.2124 => clipped to 1
+    assert efforts[0] == pytest.approx(-1.0)
+    assert efforts[1] == pytest.approx(0.0, abs=1e-4)
     assert efforts[2] == pytest.approx(1.0)
 
     # Test with strafe that should clip
     vx_strafe, vy_strafe, v_omega_strafe = 0.0, kinematics_params["max_wheel_speed"] * 1.5, 0.0 # vy = 0.5 * 1.5 = 0.75
     efforts_strafe = calculate_expected_wheel_efforts(vx_strafe, vy_strafe, v_omega_strafe, **kinematics_params)
-    # v_w1 = 0.75 => e1_unclipped = 0.75/0.5 = 1.5 => e1_clipped = 1.0
-    # v_w2 = -0.5 * 0.75 = -0.375 => e2 = -0.375/0.5 = -0.75
-    # v_w3 = -0.5 * 0.75 = -0.375 => e3 = -0.375/0.5 = -0.75
-    assert efforts_strafe[0] == pytest.approx(1.0)
-    assert efforts_strafe[1] == pytest.approx(-0.75)
-    assert efforts_strafe[2] == pytest.approx(-0.75)
+    # v_w1 = 0.375 => e1 = 0.75
+    # v_w2 = -0.75  => e2 = -1.5 => clipped to -1
+    # v_w3 = 0.375  => e3 = 0.75
+    assert efforts_strafe[0] == pytest.approx(0.75)
+    assert efforts_strafe[1] == pytest.approx(-1.0)
+    assert efforts_strafe[2] == pytest.approx(0.75)


### PR DESCRIPTION
## Summary
- add wheel_base_radius parameter
- rework `calculate_wheel_efforts` to use 60°/180°/300° wheel layout
- update expected kinematics calculations in unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aca054f388323ac5815533d82884c