### PR TITLE
Implement customizable discharge zones

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -123,6 +123,9 @@ ros2 param set /robot_control_node mission.total_balls_to_collect 4
 - `mission.balls_for_first_phase`: 第1フェーズ目標個数 (default: 2)
 - `mission.total_balls_to_collect`: 総収集目標 (default: 4)
 - `mission.discharge_wait_duration_s`: 排出待機時間 (default: 5.0 s)
+- `mission.ball_capacity`: 一度に保持できるボール数上限 (default: 5)
+- `mission.discharge_zone_colors`: 各排出ゾーンに対応するボール色順
+  (default: ["red", "blue", "yellow"])
 
 ## トピック
 


### PR DESCRIPTION
## Summary
- add `mission.discharge_zone_colors` parameter to configure ball colors for each zone
- navigate between discharge zones using a new MOVE_TO_NEXT_ZONE stage
- rotate before discharging and handle each zone sequentially
- update README with the new parameter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684bd69e56f88323a9f75603fd89dad8